### PR TITLE
fixed deprecated neo_proto and bug with phsyx cfg

### DIFF
--- a/forward_locomotion/go1_gym/envs/base/legged_robot_config.py
+++ b/forward_locomotion/go1_gym/envs/base/legged_robot_config.py
@@ -1,4 +1,4 @@
-from params_proto.neo_proto import PrefixProto, ParamsProto
+from params_proto import PrefixProto, ParamsProto
 import os
 import random
 

--- a/forward_locomotion/go1_gym/envs/base/legged_robot_config_template.py
+++ b/forward_locomotion/go1_gym/envs/base/legged_robot_config_template.py
@@ -1,4 +1,4 @@
-from params_proto.neo_proto import PrefixProto, ParamsProto
+from params_proto import PrefixProto, ParamsProto
 import os
 import random
 

--- a/forward_locomotion/go1_gym/envs/go1/go1_config.py
+++ b/forward_locomotion/go1_gym/envs/go1/go1_config.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from params_proto.neo_proto import Meta
+from params_proto import Meta
 
 from forward_locomotion.go1_gym.envs.base.legged_robot_config import Cfg
 

--- a/forward_locomotion/go1_gym/envs/mini_cheetah/mini_cheetah_config.py
+++ b/forward_locomotion/go1_gym/envs/mini_cheetah/mini_cheetah_config.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from params_proto.neo_proto import Meta
+from params_proto import Meta
 
 from forward_locomotion.go1_gym.envs.base.legged_robot_config import Cfg
 

--- a/forward_locomotion/go1_gym/envs/mini_cheetah/velocity_tracking/velocity_tracking_easy_env.py
+++ b/forward_locomotion/go1_gym/envs/mini_cheetah/velocity_tracking/velocity_tracking_easy_env.py
@@ -1,6 +1,6 @@
 from isaacgym import gymutil, gymapi
 import torch
-from params_proto.neo_proto import Meta
+from params_proto import Meta
 from typing import Union
 
 from forward_locomotion.go1_gym.envs.base.legged_robot import LeggedRobot
@@ -35,6 +35,7 @@ class VelocityTrackingEasyEnv(LeggedRobot):
             cfg.commands.heading_command = False
 
         sim_params = gymapi.SimParams()
+        cfg.sim.physx = vars(cfg.sim.physx)
         gymutil.parse_sim_config(vars(cfg.sim), sim_params)
         super().__init__(cfg, sim_params, physics_engine, sim_device, headless, eval_cfg, initial_dynamics_dict)
 

--- a/forward_locomotion/go1_gym_learn/ppo/__init__.py
+++ b/forward_locomotion/go1_gym_learn/ppo/__init__.py
@@ -5,7 +5,7 @@ from collections import deque
 
 import torch
 from ml_logger import logger
-from params_proto.neo_proto import PrefixProto
+from params_proto import PrefixProto
 import os
 import copy
 

--- a/forward_locomotion/go1_gym_learn/ppo/actor_critic.py
+++ b/forward_locomotion/go1_gym_learn/ppo/actor_critic.py
@@ -2,7 +2,7 @@
 
 import torch
 import torch.nn as nn
-from params_proto.neo_proto import PrefixProto
+from params_proto import PrefixProto
 from torch.distributions import Normal
 
 

--- a/forward_locomotion/go1_gym_learn/ppo/ppo.py
+++ b/forward_locomotion/go1_gym_learn/ppo/ppo.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
 import numpy as np
-from params_proto.neo_proto import PrefixProto
+from params_proto import PrefixProto
 
 from forward_locomotion.go1_gym_learn.ppo import ActorCritic
 from forward_locomotion.go1_gym_learn.ppo import RolloutStorage


### PR DESCRIPTION
Regarding the issue #4  with training for forward locomotion and having all runs fail, after checking the logs, I have located the following issues:
- neo_proto is deprecated thus should be removed
- cfg.sim.physx should be wrapped around vars(cfg.sim.physx)
- Numpy deprecated np.float in 1.20, which is used in isaac gym preview 4, thus numpy version must be <1.20